### PR TITLE
Fix image handling in terminal-based Emacs on a Raspberry Pi.

### DIFF
--- a/nov.el
+++ b/nov.el
@@ -445,14 +445,15 @@ This function honors `shr-max-image-proportion' if possible."
   "Custom <img> rendering function for DOM.
 Uses `shr-tag-img' for external paths and `nov-insert-image' for
 internal ones."
-  (let ((url (or url (cdr (assq 'src (cadr dom))))))
-    (if (nov-external-url-p url)
-        ;; HACK: avoid hanging in an infinite loop when using
-        ;; `cl-letf' to override `shr-tag-img' with a function that
-        ;; might call `shr-tag-img' again
-        (funcall nov-original-shr-tag-img-function dom url)
-      (setq url (expand-file-name (nov-urldecode url)))
-      (nov-insert-image url))))
+  (if (display-graphic-p)
+      (let ((url (or url (cdr (assq 'src (cadr dom))))))
+        (if (nov-external-url-p url)
+            ;; HACK: avoid hanging in an infinite loop when using
+            ;; `cl-letf' to override `shr-tag-img' with a function that
+            ;; might call `shr-tag-img' again
+            (funcall nov-original-shr-tag-img-function dom url)
+          (setq url (expand-file-name (nov-urldecode url)))
+          (nov-insert-image url)))))
 
 (defun nov-render-title (dom)
   "Custom <title> rendering function for DOM.


### PR DESCRIPTION
Bug: nov.el fails to render any content within a chapter after the first image on a Raspberry Pi 3 running Raspbian Buster in terminal-based Emacs. Emacs reports an "Invalid image type 'jpeg'" error with a backtrace from shr-descend through nov-render-img, nov-insert-image, create-image, and image-type before generating that error.

Making the body of nov-render-img conditional on display-graphic-p appears to fix this.

I suspect the bug of image handling in a terminal environment is actually located in shr, but the backtrace includes several copies of a lisp-ified version of the html file, which I found unfriendly to debug.

This problem did not arise on Debian Buster (amd64; non-graphic) or macOS (10.14, running emacs-plus from Homebrew; graphic and non-graphic). This change was tested in each and does not appear to create any problems in any of these environments.